### PR TITLE
[#2] As a user, I can initialize the project with a 'make' command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Python
+.venv/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: help prepare-dev init
+
+# Python stuff
+VENV_NAME?=.venv
+PYTHON3 := $(shell command -v python3 2> /dev/null)
+VENV_ACTIVATE=$(VENV_NAME)/bin/activate
+PYTHON=$(VENV_NAME)/bin/python3
+
+PACKAGE_NAME=co.nimblehq.flutter.template
+PROJECT_NAME=flutter_templates
+APP_NAME=Flutter Templates
+
+.DEFAULT: help
+help:
+	@echo "make prepare-dev"
+	@echo "        prepare development environment, use only once"
+	@echo "make init PACKAGE_NAME=com.example PROJECT_NAME=new_templates"
+	@echo "        init project with the new package name and project name"
+
+prepare-dev:
+	@if [ -z $(PYTHON3) ]; then \
+		echo "python3 could not be found. Installing..."; \
+		brew install python3; \
+	fi
+	python3 -m pip install pipenv
+	python3 -m venv $(VENV_NAME)
+
+init: prepare-dev
+	$(PYTHON) ./scripts/setup.py --project_path $(PWD) --package_name $(PACKAGE_NAME) --project_name $(PROJECT_NAME)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help prepare-dev init test
+.PHONY: help prepare-dev init test run
 
 # Python stuff
 VENV_NAME?=.venv
@@ -10,8 +10,15 @@ PACKAGE_NAME=co.nimblehq.flutter.template
 PROJECT_NAME=flutter_templates
 APP_NAME=Flutter Templates
 
+# Add the variable to env
+export PACKAGE_NAME
+export PROJECT_NAME
+export APP_NAME
+
 .DEFAULT: help
 help:
+	@echo "make run PACKAGE_NAME=com.your.package PROJECT_NAME=your_project_name APP_NAME=\"Your App Name\""
+	@echo "        init the project then run all the test"
 	@echo "make prepare-dev"
 	@echo "        prepare development environment, use only once"
 	@echo "make init PACKAGE_NAME=com.your.package PROJECT_NAME=your_project_name APP_NAME=\"Your App Name\""
@@ -32,3 +39,5 @@ init: prepare-dev
 
 test: prepare-dev
 	$(PYTHON) ./scripts/test.py
+
+run: init test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help prepare-dev init
+.PHONY: help prepare-dev init test
 
 # Python stuff
 VENV_NAME?=.venv
@@ -16,6 +16,8 @@ help:
 	@echo "        prepare development environment, use only once"
 	@echo "make init PACKAGE_NAME=com.example PROJECT_NAME=new_templates"
 	@echo "        init project with the new package name and project name"
+	@echo "make test"
+	@echo "        run the tests for the setup.py script"
 
 prepare-dev:
 	@if [ -z $(PYTHON3) ]; then \
@@ -27,3 +29,6 @@ prepare-dev:
 
 init: prepare-dev
 	$(PYTHON) ./scripts/setup.py --project_path $(PWD) --package_name $(PACKAGE_NAME) --project_name $(PROJECT_NAME)
+
+test: prepare-dev
+	$(PYTHON) ./scripts/test.py

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ APP_NAME=Flutter Templates
 help:
 	@echo "make prepare-dev"
 	@echo "        prepare development environment, use only once"
-	@echo "make init PACKAGE_NAME=com.your.package PROJECT_NAME=your_project_name"
-	@echo "        init project with the new package name and project name"
+	@echo "make init PACKAGE_NAME=com.your.package PROJECT_NAME=your_project_name APP_NAME=\"Your App Name\""
+	@echo "        init project with the new package name, the new project name and the new app name"
 	@echo "make test"
 	@echo "        run the tests for the setup.py script"
 
@@ -28,7 +28,7 @@ prepare-dev:
 	python3 -m venv $(VENV_NAME)
 
 init: prepare-dev
-	$(PYTHON) ./scripts/setup.py --project_path $(PWD) --package_name $(PACKAGE_NAME) --project_name $(PROJECT_NAME)
+	$(PYTHON) ./scripts/setup.py --project_path $(PWD) --package_name $(PACKAGE_NAME) --project_name $(PROJECT_NAME) --app_name "$(APP_NAME)"
 
 test: prepare-dev
 	$(PYTHON) ./scripts/test.py

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ APP_NAME=Flutter Templates
 help:
 	@echo "make prepare-dev"
 	@echo "        prepare development environment, use only once"
-	@echo "make init PACKAGE_NAME=com.example PROJECT_NAME=new_templates"
+	@echo "make init PACKAGE_NAME=com.your.package PROJECT_NAME=your_project_name"
 	@echo "        init project with the new package name and project name"
 	@echo "make test"
 	@echo "        run the tests for the setup.py script"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Clone the repository
 
 - To set up a new project from the template, run the command:
 
-  - `$ make init PACKAGE_NAME={com.your.package} PROJECT_NAME={your_project_name} APP_NAME="{Your App Name}"`
+  - `$ make run PACKAGE_NAME={com.your.package} PROJECT_NAME={your_project_name} APP_NAME="{Your App Name}"`
 
   - Then clean the project: `$ fvm flutter clean`
 

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ Clone the repository
 
 - To set up a new project from the template, run the command:
 
-  - `$ make init PACKAGE_NAME={com.your.package} PROJECT_NAME={your_project_name}`
+  - `$ make init PACKAGE_NAME={com.your.package} PROJECT_NAME={your_project_name} APP_NAME="{Your App Name}"`
 
   - Then clean the project: `$ fvm flutter clean`
 
   - Re-fetch the project: `$ fvm flutter pub get`
 
-- The project uses the package name and the project name of the template if `PACKAGE_NAME` and `PROJECT_NAME` aren't specified.
+- The project uses the package name, the app name and the project name of the template if `PACKAGE_NAME`, `APP_NAME` and `PROJECT_NAME` aren't specified.
 
 - For more supporting commands, run:
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,34 @@ Clone the repository
   
   - `$ fvm flutter packages pub run build_runner build --delete-conflicting-outputs`
 
+## Use the template
+
+### Setup a new project
+
+- To set up a new project from the template, run the command:
+
+  - `$ make init PACKAGE_NAME=${com.example} PROJECT_NAME=${project_name}`
+
+  - Then clean the project: `$ fvm flutter clean`
+
+  - Re-fetch the project: `$ fvm flutter pub get`
+
+- The project uses the package name and the project name of the template if `PACKAGE_NAME` and `PROJECT_NAME` aren't specified.
+
+- For more supporting commands, run:
+
+  - `$ make`
+
+  - Or `$ make help`
+
+### Maintain the template
+
+- While implementing a new feature or fixing an issue, there may be a chance to break the functions of `setup.py` script due to the change in the codebase (update the app name, the package directory, etc.).
+
+- To make sure that the `setup.py` script is still working correctly, run the command:
+
+  - `$ make test`
+
 ## License
 
 This project is Copyright (c) 2014 and onwards. It is free software,

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Clone the repository
 
 - To set up a new project from the template, run the command:
 
-  - `$ make init PACKAGE_NAME=${com.example} PROJECT_NAME=${project_name}`
+  - `$ make init PACKAGE_NAME={com.your.package} PROJECT_NAME={your_project_name}`
 
   - Then clean the project: `$ fvm flutter clean`
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -162,8 +162,8 @@ class Ios:
                 return line.strip().replace("<string>", "").replace("</string>", "")
         return None
 
-    def replace_text(self, contain_text, old_text, new_text):
-        f = open(self.project_file, "r")
+    def replace_text_in_file(self, file_path, contain_text, old_text, new_text):
+        f = open(file_path, "r")
         try:
             file_text = f.read()
             f.close()
@@ -173,7 +173,7 @@ class Ios:
                     new_content += "\n" + line.replace(old_text, new_text)
                 else:
                     new_content += "\n" + line
-            f = open(self.project_file, "w")
+            f = open(file_path, "w")
             f.write(new_content)
             f.close()
         except UnicodeDecodeError:  # This file is not text plain
@@ -182,7 +182,8 @@ class Ios:
     def repackage(self):
         old_package = self.get_old_package()
         if old_package is not None and old_package != self.project.new_package:
-            self.replace_text("PRODUCT_BUNDLE_IDENTIFIER", old_package, self.project.new_package)
+            self.replace_text_in_file(file_path=self.project_file, contain_text="PRODUCT_BUNDLE_IDENTIFIER",
+                                      old_text=old_package, new_text=self.project.new_package)
             print("Update package name for iOS successfully!")
         elif old_package is None:
             print("Bundle identifier not found in Runner.xcodeproj/project.pbxproj!")
@@ -192,7 +193,8 @@ class Ios:
     def rename_app(self):
         old_app_name = self.get_old_app_name()
         if old_app_name is not None and old_app_name != self.project.new_app_name:
-            self.replace_text("APP_DISPLAY_NAME", old_app_name, self.project.new_app_name)
+            self.replace_text_in_file(file_path=self.project_file, contain_text="APP_DISPLAY_NAME",
+                                      old_tet=old_app_name, new_text=self.project.new_app_name)
             print("✅  Rename iOS app successully!")
         elif old_app_name is None:
             print("Unable to find the old app name for iOS!")
@@ -201,7 +203,10 @@ class Ios:
     def rename_project(self):
         old_project_name = self.get_old_project_name()
         if old_project_name is not None and old_project_name != self.project.new_project_name:
-            self.replace_text(old_project_name, old_project_name, self.project.new_project_name)
+            self.replace_text_in_file(file_path=self.project_file, contain_text=old_project_name,
+                                      old_text=old_project_name, new_text=self.project.new_project_name)
+            self.replace_text_in_file(file_path=self.info_file, contain_text=old_project_name,
+                                      old_text=old_project_name, new_text=self.project.new_project_name)
             print(f'✅  Renamed to {self.project.new_project_name} in iOS succesfully!')
         elif old_project_name is None:
             print("Unable to update project name in iOS! Please check again!")

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -25,6 +25,7 @@ class Android:
         build_file = self.initial_folder + os.sep + ANDROID_MODULE + os.sep + "build.gradle"
         f = open(build_file, "r")
         file_text = f.read()
+        f.close()
         for line in file_text.split("\n"):
             if "applicationId" in line.strip():
                 return line.strip().split(" ")[1].strip().replace("\"", "")
@@ -35,6 +36,7 @@ class Android:
             os.sep + "main" + os.sep + "res" + os.sep + "values" + os.sep + "strings.xml"
         f = open(string_res_file, "r")
         file_text = f.read()
+        f.close()
         for line in file_text.split("\n"):
             if "app_name" in line.strip():
                 return line.strip().replace("<string name=\"app_name\">",
@@ -135,6 +137,7 @@ class Ios:
     def get_old_package(self):
         f = open(self.project_file, "r")
         file_text = f.read()
+        f.close()
         for line in file_text.split("\n"):
             if "PRODUCT_BUNDLE_IDENTIFIER" in line.strip():
                 return line.strip().split(" = ")[1].strip().replace(";", "").replace(".staging", "")
@@ -143,6 +146,7 @@ class Ios:
     def get_old_app_name(self):
         f = open(self.project_file, "r")
         file_text = f.read()
+        f.close()
         for line in file_text.split("\n"):
             if "APP_DISPLAY_NAME" in line.strip():
                 return line.strip().split(" = ")[1].strip().replace("\"", "")\
@@ -152,6 +156,7 @@ class Ios:
     def get_old_project_name(self):
         f = open(self.info_file, "r")
         file_text = f.read()
+        f.close()
         for line in file_text.split("\n"):
             if "flutter_templates" in line.strip():
                 return line.strip().replace("<string>", "").replace("</string>", "")
@@ -221,6 +226,7 @@ class Flutter:
         pubspec_file = self.project.project_path + os.sep + "pubspec.yaml"
         f = open(pubspec_file, "r")
         file_text = f.read()
+        f.close()
         for line in file_text.split("\n"):
             if "name:" in line.strip():
                 return line.strip().replace("name:", "").strip()

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -159,9 +159,10 @@ class Ios:
         f = open(self.info_file, "r")
         file_text = f.read()
         f.close()
-        for line in file_text.split("\n"):
-            if "flutter_templates" in line.strip():
-                return line.strip().replace("<string>", "").replace("</string>", "")
+        file_text_list = file_text.split("\n")
+        for index, line in enumerate(file_text_list):
+            if "CFBundleName" in line.strip():
+                return file_text_list[index + 1].strip().replace("<string>", "").replace("</string>", "")
         return None
 
     def replace_text_in_file(self, file_path, contain_text, old_text, new_text):

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -91,11 +91,14 @@ class Android:
 
     def rename_app(self):
         old_app_name = self.get_old_app_name()
-        if old_app_name is not None:
+        if old_app_name is not None and old_app_name != self.project.new_app_name:
             self.update_name(self.initial_folder, old_app_name, self.project.new_app_name)
-            print("Rename Android app successfully!")
-        else:
+            print("✅  Rename Android app successfully!")
+        elif old_app_name is None:
             print("Unable to find the old app name for Android!")
+            sys.exit()
+        else:
+            print("Reusing old app name in Android!")
 
     def replace_text(self, path_file, old_text, new_text):
         f = open(path_file, "r")
@@ -122,8 +125,7 @@ class Android:
                 self.replace_text(path_folder + os.sep + str(f), old_name, new_name)
 
     def run(self):
-        # Uncomment if we want to rename Flutter Templates to other name
-        # self.rename_app()
+        self.rename_app()
         self.repackage()
 
 
@@ -194,11 +196,13 @@ class Ios:
         old_app_name = self.get_old_app_name()
         if old_app_name is not None and old_app_name != self.project.new_app_name:
             self.replace_text_in_file(file_path=self.project_file, contain_text="APP_DISPLAY_NAME",
-                                      old_tet=old_app_name, new_text=self.project.new_app_name)
+                                      old_text=old_app_name, new_text=self.project.new_app_name)
             print("✅  Rename iOS app successully!")
         elif old_app_name is None:
             print("Unable to find the old app name for iOS!")
             sys.exit()
+        else:
+            print("Reusing old app name in iOS!")
 
     def rename_project(self):
         old_project_name = self.get_old_project_name()
@@ -215,8 +219,7 @@ class Ios:
             print("Reusing old project name in iOS!")
 
     def run(self):
-        # Uncomment if we want to rename Flutter Templates to other name
-        # self.rename_app()
+        self.rename_app()
         self.rename_project()
         self.repackage()
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+# coding:utf-8
+
+import os
+import sys
+import shutil
+import argparse
+import re
+
+PACKAGE_SEPARATOR = "."
+ANDROID_MODULE = "app"  # only app module now
+
+
+class Project:
+    def __init__(self):
+        pass
+
+
+class Android:
+    def __init__(self, p):
+        self.project = p
+        self.initial_folder = p.project_path + os.sep + "android"
+
+    def get_old_package(self):
+        build_file = self.initial_folder + os.sep + ANDROID_MODULE + os.sep + "build.gradle"
+        f = open(build_file, "r")
+        file_text = f.read()
+        for line in file_text.split("\n"):
+            if "applicationId" in line.strip():
+                return line.strip().split(" ")[1].strip().replace("\"", "")
+        return None
+
+    def get_old_app_name(self):
+        string_res_file = self.initial_folder + os.sep + ANDROID_MODULE + os.sep + "src" + \
+            os.sep + "main" + os.sep + "res" + os.sep + "values" + os.sep + "strings.xml"
+        f = open(string_res_file, "r")
+        file_text = f.read()
+        for line in file_text.split("\n"):
+            if "app_name" in line.strip():
+                return line.strip().replace("<string name=\"app_name\">",
+                                            "").replace("</string>", "")
+        return None
+
+    def check_original_route(self, old_package):
+        print("Checking original package...")
+        original_route = self.initial_folder + os.sep + ANDROID_MODULE + os.sep + "src" + os.sep + \
+            "main" + os.sep + "kotlin" + os.sep + old_package.replace(PACKAGE_SEPARATOR, os.sep)
+        if os.path.isdir(original_route):
+            print("Original package exists! Updating package...")
+        else:
+            print(
+                "Original package not found, please write a correct original package!"
+            )
+            sys.exit()
+
+    def move_code_folder(self, folder_name, old_package):
+        original_route = self.initial_folder + os.sep + ANDROID_MODULE + os.sep + "src" + os.sep + \
+            folder_name + os.sep + "kotlin" + os.sep + \
+            old_package.replace(PACKAGE_SEPARATOR, os.sep)
+        destiny_route = self.initial_folder + os.sep + ANDROID_MODULE + os.sep + "src" + os.sep + \
+            folder_name + os.sep + "kotlin" + os.sep + \
+            self.project.new_package.replace(PACKAGE_SEPARATOR, os.sep)
+        shutil.move(original_route, self.initial_folder + os.sep +
+                    ANDROID_MODULE + os.sep + "my_temporal_folder")
+        shutil.rmtree(self.initial_folder + os.sep + ANDROID_MODULE + os.sep +
+                      "src" + os.sep + folder_name + os.sep + "kotlin" + os.sep)
+        shutil.move(self.initial_folder + os.sep + ANDROID_MODULE +
+                    os.sep + "my_temporal_folder", destiny_route)
+
+    def move_folders(self, old_package):
+        path_folder = self.initial_folder + os.sep + ANDROID_MODULE + os.sep + "src"
+        for f in os.listdir(path_folder):
+            # Only rename package in main
+            if os.path.isdir(path_folder + os.sep + f) and f == 'main':
+                self.move_code_folder(str(f), old_package)
+
+    def repackage(self):
+        old_package = self.get_old_package()
+        if old_package is not None and old_package != self.project.new_package:
+            self.check_original_route(old_package)
+            self.update_name(self.initial_folder, old_package, self.project.new_package)
+            self.move_folders(old_package)
+            print("✅  Update package name for Android successfully!")
+        elif old_package is None:
+            print("applicationId not found in app/build.gradle... Exiting!")
+            sys.exit()
+        else:
+            print("Reusing old package name in Android!")
+
+    def rename_app(self):
+        old_app_name = self.get_old_app_name()
+        if old_app_name is not None:
+            self.update_name(self.initial_folder, old_app_name, self.project.new_app_name)
+            print("Rename Android app successfully!")
+        else:
+            print("Unable to find the old app name for Android!")
+
+    def replace_text(self, path_file, old_text, new_text):
+        f = open(path_file, "r")
+        try:
+            file_text = f.read()
+            f.close()
+            t = file_text.replace(old_text, new_text)
+            f = open(path_file, "w")
+            f.write(t)
+            f.close()
+        except UnicodeDecodeError:  # This file is not text plain
+            f.close()
+
+    def update_name(self, path_folder, old_name, new_name):
+        for f in os.listdir(path_folder):
+            # is a folder
+            if os.path.isdir(path_folder + os.sep + f):
+                abs_path = os.path.abspath(path_folder + os.sep + str(f))
+                # ignore build folder
+                if str(f) != "build":
+                    self.update_name(abs_path, old_name, new_name)
+            # is a file
+            else:
+                self.replace_text(path_folder + os.sep + str(f), old_name, new_name)
+
+    def run(self):
+        # Uncomment if we want to rename Flutter Templates to other name
+        # self.rename_app()
+        self.repackage()
+
+
+class Ios:
+    def __init__(self, p):
+        self.project = p
+        self.project_file = p.project_path + os.sep + "ios" + \
+            os.sep + "Runner.xcodeproj" + os.sep + "project.pbxproj"
+        self.info_file = p.project_path + os.sep + "ios" + os.sep + "Runner" + os.sep + "Info.plist"
+
+    def get_old_package(self):
+        f = open(self.project_file, "r")
+        file_text = f.read()
+        for line in file_text.split("\n"):
+            if "PRODUCT_BUNDLE_IDENTIFIER" in line.strip():
+                return line.strip().split(" = ")[1].strip().replace(";", "").replace(".staging", "")
+        return None
+
+    def get_old_app_name(self):
+        f = open(self.project_file, "r")
+        file_text = f.read()
+        for line in file_text.split("\n"):
+            if "APP_DISPLAY_NAME" in line.strip():
+                return line.strip().split(" = ")[1].strip().replace("\"", "")\
+                    .replace(";", "").replace(" Staging", "").replace(" Production", "")
+        return None
+
+    def get_old_project_name(self):
+        f = open(self.info_file, "r")
+        file_text = f.read()
+        for line in file_text.split("\n"):
+            if "flutter_templates" in line.strip():
+                return line.strip().replace("<string>", "").replace("</string>", "")
+        return None
+
+    def replace_text(self, contain_text, old_text, new_text):
+        f = open(self.project_file, "r")
+        try:
+            file_text = f.read()
+            f.close()
+            new_content = ""
+            for line in file_text.split("\n"):
+                if contain_text in line.strip():
+                    new_content += "\n" + line.replace(old_text, new_text)
+                else:
+                    new_content += "\n" + line
+            f = open(self.project_file, "w")
+            f.write(new_content)
+            f.close()
+        except UnicodeDecodeError:  # This file is not text plain
+            f.close()
+
+    def repackage(self):
+        old_package = self.get_old_package()
+        if old_package is not None and old_package != self.project.new_package:
+            self.replace_text("PRODUCT_BUNDLE_IDENTIFIER", old_package, self.project.new_package)
+            print("Update package name for iOS successfully!")
+        elif old_package is None:
+            print("Bundle identifier not found in Runner.xcodeproj/project.pbxproj!")
+        else:
+            print("Reusing old package name in iOS!")
+
+    def rename_app(self):
+        old_app_name = self.get_old_app_name()
+        if old_app_name is not None and old_app_name != self.project.new_app_name:
+            self.replace_text("APP_DISPLAY_NAME", old_app_name, self.project.new_app_name)
+            print("✅  Rename iOS app successully!")
+        elif old_app_name is None:
+            print("Unable to find the old app name for iOS!")
+            sys.exit()
+
+    def rename_project(self):
+        old_project_name = self.get_old_project_name()
+        if old_project_name is not None and old_project_name != self.project.new_project_name:
+            self.replace_text(old_project_name, old_project_name, self.project.new_project_name)
+            print(f'✅  Renamed to {self.project.new_project_name} in iOS succesfully!')
+        elif old_project_name is None:
+            print("Unable to update project name in iOS! Please check again!")
+            sys.exit()
+        else:
+            print("Reusing old project name in iOS!")
+
+    def run(self):
+        # Uncomment if we want to rename Flutter Templates to other name
+        # self.rename_app()
+        self.rename_project()
+        self.repackage()
+
+
+class Flutter:
+    def __init__(self, p):
+        self.project = p
+        self.includes = ['lib', 'test', 'test_driver',
+                         'integration_test', 'pubspec.yaml', 'README.md']
+
+    def get_old_project_name(self):
+        pubspec_file = self.project.project_path + os.sep + "pubspec.yaml"
+        f = open(pubspec_file, "r")
+        file_text = f.read()
+        for line in file_text.split("\n"):
+            if "name:" in line.strip():
+                return line.strip().replace("name:", "").strip()
+        return None
+
+    def replace_text(self, path_file, old_text, new_text):
+        f = open(path_file, "r")
+        try:
+            file_text = f.read()
+            f.close()
+            t = file_text.replace(old_text, new_text)
+            f = open(path_file, "w")
+            f.write(t)
+            f.close()
+        except UnicodeDecodeError:  # This file is not text plain
+            f.close()
+
+    def rename_project(self):
+        old_project_name = self.get_old_project_name()
+        if old_project_name is not None and old_project_name != self.project.new_project_name:
+            for root in self.includes:
+                path = os.path.join(self.project.project_path, root)
+                if os.path.isdir(path):
+                    for current, dirs, files in os.walk(path):
+                        for name in files:
+                            self.replace_text(os.path.join(current, name),
+                                              old_project_name, self.project.new_project_name)
+                else:
+                    self.replace_text(path, old_project_name, self.project.new_project_name)
+            print(f'✅  Renamed to {self.project.new_project_name} in Flutter succesfully!')
+        elif old_project_name is None:
+            print("Unable to update project name in Flutter! Please check again!")
+            sys.exit()
+        else:
+            print("Reusing old project name in Flutter!")
+
+    def run(self):
+        self.rename_project()
+
+
+def handleParameters():
+    parser = argparse.ArgumentParser(
+        description='The necessary arguments for renaming package and project.'
+    )
+    parser.add_argument('--project_path',
+                        type=str,
+                        required=True,
+                        help='The project path')
+    parser.add_argument('--package_name',
+                        type=str,
+                        default='co.nimblehq.flutter.template',
+                        help='The new package name')
+    parser.add_argument('--app_name',
+                        type=str,
+                        default='Flutter Templates',
+                        help='The app name')
+    parser.add_argument('--project_name',
+                        type=str,
+                        default='flutter_templates',
+                        help='The project name')
+
+    return parser.parse_args()
+
+
+def validateParameters(project):
+    if re.match(r'^[a-z][a-z0-9_]*(\.[a-z0-9_]+)+[0-9a-z_]$', project.new_package) is None:
+        print(
+            f"Invalid Package Name: {project.new_package} (needs to follow standard pattern `com.example.package`)")
+        sys.exit()
+    if re.match(r'^[a-z]*([a-z0-9_]+)*[a-z0-9]$', project.new_project_name) is None:
+        print(
+            f"Invalid Project Name: {project.new_project_name} (needs to follow standard pattern `lowercase_with_underscores`)")
+        sys.exit()
+
+
+if __name__ == "__main__":
+    args = handleParameters()
+
+    project = Project()
+    project.project_path = args.project_path
+    project.new_package = args.package_name
+    project.new_app_name = args.app_name
+    project.new_project_name = args.project_name
+    validateParameters(project)
+    print(f"=> 🐢 Staring init {project.new_project_name} with {project.new_package}...")
+    android = Android(project)
+    android.run()
+    ios = Ios(project)
+    ios.run()
+    flutter = Flutter(project)
+    flutter.run()
+    print("=> 🚀 Done! App is ready to be tested 🙌")

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -294,7 +294,7 @@ def handleParameters():
 def validateParameters(project):
     if re.match(r'^[a-z][a-z0-9_]*(\.[a-z0-9_]+)+[0-9a-z_]$', project.new_package) is None:
         print(
-            f"Invalid Package Name: {project.new_package} (needs to follow standard pattern `com.example.package`)")
+            f"Invalid Package Name: {project.new_package} (needs to follow standard pattern `com.your.package`)")
         sys.exit()
     if re.match(r'^[a-z]*([a-z0-9_]+)*[a-z0-9]$', project.new_project_name) is None:
         print(

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -12,16 +12,20 @@ project.new_package = 'com.example'
 project.new_app_name = ''
 project.new_project_name = 'example_project'
 
+package_name = os.getenv('PACKAGE_NAME') or "co.nimblehq.flutter.template"
+project_name = os.getenv('PROJECT_NAME') or "flutter_templates"
+app_name = os.getenv('APP_NAME') or "Flutter Templates"
+
 
 class AndroidTest(unittest.TestCase):
     def setUp(self):
         self.android = Android(project)
 
     def test_get_old_package(self):
-        self.assertEqual(self.android.get_old_package(), 'co.nimblehq.flutter.template')
+        self.assertEqual(self.android.get_old_package(), package_name)
 
     def test_get_old_app_name(self):
-        self.assertEqual(self.android.get_old_app_name(), 'Flutter Templates')
+        self.assertEqual(self.android.get_old_app_name(), app_name)
 
     def test_check_original_route(self):
         old_package = self.android.get_old_package()
@@ -33,13 +37,13 @@ class IosTest(unittest.TestCase):
         self.ios = Ios(project)
 
     def test_get_old_package(self):
-        self.assertEqual(self.ios.get_old_package(), 'co.nimblehq.flutter.template')
+        self.assertEqual(self.ios.get_old_package(), package_name)
 
     def test_get_old_app_name(self):
-        self.assertEqual(self.ios.get_old_app_name(), 'Flutter Templates')
+        self.assertEqual(self.ios.get_old_app_name(), app_name)
 
     def test_get_old_project_name(self):
-        self.assertEqual(self.ios.get_old_project_name(), 'flutter_templates')
+        self.assertEqual(self.ios.get_old_project_name(), project_name)
 
 
 class FlutterTest(unittest.TestCase):
@@ -47,7 +51,7 @@ class FlutterTest(unittest.TestCase):
         self.flutter = Flutter(project)
 
     def test_get_old_project_name(self):
-        self.assertEqual(self.flutter.get_old_project_name(), 'flutter_templates')
+        self.assertEqual(self.flutter.get_old_project_name(), project_name)
 
 
 if __name__ == '__main__':

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# coding:utf-8
+
+import os
+import unittest
+
+from setup import Android, Project, Ios, Flutter
+
+project = Project()
+project.project_path = os.path.curdir
+project.new_package = 'com.example'
+project.new_app_name = ''
+project.new_project_name = 'example_project'
+
+
+class AndroidTest(unittest.TestCase):
+    def setUp(self):
+        self.android = Android(project)
+
+    def test_get_old_package(self):
+        self.assertEqual(self.android.get_old_package(), 'co.nimblehq.flutter.template')
+
+    def test_get_old_app_name(self):
+        self.assertEqual(self.android.get_old_app_name(), 'Flutter Templates')
+
+    def test_check_original_route(self):
+        old_package = self.android.get_old_package()
+        self.assertEqual(self.android.check_original_route(old_package), None)
+
+
+class IosTest(unittest.TestCase):
+    def setUp(self):
+        self.ios = Ios(project)
+
+    def test_get_old_package(self):
+        self.assertEqual(self.ios.get_old_package(), 'co.nimblehq.flutter.template')
+
+    def test_get_old_app_name(self):
+        self.assertEqual(self.ios.get_old_app_name(), 'Flutter Templates')
+
+    def test_get_old_project_name(self):
+        self.assertEqual(self.ios.get_old_project_name(), 'flutter_templates')
+
+
+class FlutterTest(unittest.TestCase):
+    def setUp(self):
+        self.flutter = Flutter(project)
+
+    def test_get_old_project_name(self):
+        self.assertEqual(self.flutter.get_old_project_name(), 'flutter_templates')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
https://github.com/nimblehq/flutter_templates/issues/2

## What happened 👀

Once checking out the project from the main branch, we should make the process to initialize the project intuitively.

## Insight 📝

- Allow the user to name their project.
- Allow the user to name their project package name.
- How to use:
  - On the project level, we run one command to update the package name and the project name at the same time. It is: `make init PACKAGE_NAME=${com.example} PROJECT_NAME=${project_name} APP_NAME="{Your App Name}"`
    - If not defining `PACKAGE_NAME`, `APP_NAME` or `PROJECT_NAME`, we will reuse the old name
  - There are some prerequisite steps that are included in `Makefile` also. They are: `install python3` and `install an isolated environment for Python3`. If we want to check this step, just run `make prepare-dev`. If there is an error, please raise it to me so I can fix it 😅 
  - Last but not least, run `make help` or `make` to show the help.

## Proof Of Work 📹


https://user-images.githubusercontent.com/60863885/137101656-00096bdc-3543-48d6-8472-2befd936ac89.mov

