### PR TITLE
[#43] Add the config for auto renaming the `json_serializable` variable as a snake case when building the generated files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ prepare-dev:
 	fi
 	python3 -m pip install pipenv
 	python3 -m venv $(VENV_NAME)
+	$(PYTHON) -m pip install enquiries
 
 init: prepare-dev
 	$(PYTHON) ./scripts/setup.py --project_path $(PWD) --package_name "$(PACKAGE_NAME)" --project_name "$(PROJECT_NAME)" --app_name "$(APP_NAME)" --app_version "$(APP_VERSION)" --build_number "$(BUILD_NUMBER)"

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          field_rename: "snake"

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -254,6 +254,7 @@ class Flutter:
     def get_current_project_version(self):
         return self.get_value_in_pubspec_file("version:")
 
+ 	# TODO: Write unit test
     def get_json_serializable_field_rename(self):
         return self.get_value_in_build_file("field_rename:")
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -387,10 +387,15 @@ if __name__ == "__main__":
     project.build_number = args.build_number
     validateParameters(project)
 
-    options = ['none', 'kebab', 'snake', 'pascal']
-    choice = enquiries.choose('Choose default json_serializable.field_rename: ', options)
+    options = {
+		'none' : 'none',
+		'kebab (kebab-case)' : 'kebab',
+		'snake (snake_case)' : 'snake',
+		'pascal (PascalCase)' : 'pascal'
+	}
+    choice = enquiries.choose('Choose default json_serializable.field_rename: ', options.keys())
     project.json_serializable = Object()
-    project.json_serializable.field_rename = choice
+    project.json_serializable.field_rename = options[choice]
 
     print(f"=> 🐢 Staring init {project.new_project_name} with {project.new_package}...")
     android = Android(project)

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -12,9 +12,19 @@ PACKAGE_SEPARATOR = "."
 ANDROID_MODULE = "app"  # only app module now
 
 
-class Object:
-    def __init__(self):
-        pass
+class JsonSerializable:
+	def __init__(self, field_rename):
+		self.field_rename = field_rename
+
+class Project:
+	def __init__(self, project_path, new_package, new_app_name, new_project_name, app_version, build_number):
+		self.project_path = project_path
+		self.new_package = new_package
+		self.new_app_name = new_app_name
+		self.new_project_name = new_project_name
+		self.app_version = app_version
+		self.build_number = build_number
+		self.json_serializable = None
 
 
 class Android:
@@ -378,13 +388,14 @@ def validateParameters(project):
 if __name__ == "__main__":
     args = handleParameters()
 
-    project = Object()
-    project.project_path = args.project_path
-    project.new_package = args.package_name
-    project.new_app_name = args.app_name
-    project.new_project_name = args.project_name
-    project.app_version = args.app_version
-    project.build_number = args.build_number
+    project = Project(
+		args.project_path,
+		args.package_name,
+		args.app_name,
+		args.project_name,
+		args.app_version,
+		args.build_number
+	)
     validateParameters(project)
 
     options = {
@@ -394,8 +405,7 @@ if __name__ == "__main__":
 		'pascal (PascalCase)' : 'pascal'
 	}
     choice = enquiries.choose('Choose default json_serializable.field_rename: ', options.keys())
-    project.json_serializable = Object()
-    project.json_serializable.field_rename = options[choice]
+    project.json_serializable = JsonSerializable(options[choice])
 
     print(f"=> 🐢 Staring init {project.new_project_name} with {project.new_package}...")
     android = Android(project)

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -254,7 +254,7 @@ class Flutter:
     def get_current_project_version(self):
         return self.get_value_in_pubspec_file("version:")
 
- 	# TODO: Write unit test
+	# TODO: Write unit test
     def get_json_serializable_field_rename(self):
         return self.get_value_in_build_file("field_rename:")
 


### PR DESCRIPTION
https://github.com/nimblehq/flutter_templates/issues/43

## What happened 👀

- Add default `build.yaml` file
- Add a `json_serializable.field_rename` selection when executing `make run..` 

![Screen Shot 2022-03-23 at 11 14 40](https://user-images.githubusercontent.com/17875522/159622726-02087157-1b46-4db9-bd2b-18082e701989.png)



## Insight 📝

n/a

## Proof Of Work 📹

https://user-images.githubusercontent.com/17875522/159622644-a901a773-4b11-4a05-bbc3-30b336ebb488.mp4


