### PR TITLE
Update the project's maintainers info

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 * @manh-t
 
 # Team Members
-* @doannimble @luongvo @markgravity @sleepylee 
+* @doannimble @luongvo @markgravity
 
 # Engineering Leads
 CODEOWNERS @nimblehq/engineering-leads

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,8 @@
-# These users will be requested for review when someone opens a pull request.
-*       @sleepylee @luongvo @manh-t @markgravity @doannimble
+# Team Lead
+* @manh-t
+
+# Team Members
+* @doannimble @luongvo @markgravity @sleepylee 
+
+# Engineering Leads
+CODEOWNERS @nimblehq/engineering-leads


### PR DESCRIPTION
## What happened 👀

- Rework the `CODEOWNERS` in the subdirectory `.github` to follow the standardized format used on all project templates.
- Reorder the list of team members in alphabetical order.

## Insight 📝

All project template repositories now have official leads so it is crucial to have it documented. 

## Proof Of Work 📹

![image](https://user-images.githubusercontent.com/696529/160563878-bd1b4ed7-5972-440c-ba28-82352a3780a8.png)