### PR TITLE
[#56] Fix test cases failed for init script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ APP_NAME=
 APP_VERSION=0.1.0
 BUILD_NUMBER=1
 
-RUNNING_TEST_MODE=0 # 0: true, 1: false
+RUNNING_TEST_MODE=1 # 0: false, 1: true
 
 export PROJECT_PATH
 export PACKAGE_NAME
@@ -49,5 +49,5 @@ init: prepare-dev
 test: prepare-dev
 	$(PYTHON) ./scripts/test.py
 
-run: RUNNING_TEST_MODE=1
+run: RUNNING_TEST_MODE=0
 run: init test

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,15 @@ APP_NAME=
 APP_VERSION=0.1.0
 BUILD_NUMBER=1
 
-# Add the variable to env
+RUNNING_TEST_MODE=0 # 0: true, 1: false
+
 export PROJECT_PATH
 export PACKAGE_NAME
 export PROJECT_NAME
 export APP_NAME
 export APP_VERSION
 export BUILD_NUMBER
+export RUNNING_TEST_MODE
 
 .DEFAULT: help
 help:
@@ -47,4 +49,5 @@ init: prepare-dev
 test: prepare-dev
 	$(PYTHON) ./scripts/test.py
 
+run: RUNNING_TEST_MODE=1
 run: init test

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ APP_VERSION=0.1.0
 BUILD_NUMBER=1
 
 # Add the variable to env
+export PROJECT_PATH
 export PACKAGE_NAME
 export PROJECT_NAME
 export APP_NAME

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -32,7 +32,7 @@ class Android:
         self.project = p
         self.initial_folder = p.project_path + os.sep + "android"
 
-    def get_old_package(self):
+    def get_current_package_name(self):
         build_file = self.initial_folder + os.sep + ANDROID_MODULE + os.sep + "build.gradle"
         f = open(build_file, "r")
         file_text = f.read()
@@ -42,7 +42,7 @@ class Android:
                 return line.strip().split(" ")[1].strip().replace("\"", "")
         return None
 
-    def get_old_app_name(self):
+    def get_current_app_name(self):
         string_res_file = self.initial_folder + os.sep + ANDROID_MODULE + os.sep + "src" + \
             os.sep + "main" + os.sep + "res" + os.sep + "values" + os.sep + "strings.xml"
         f = open(string_res_file, "r")
@@ -88,7 +88,7 @@ class Android:
                 self.move_code_folder(str(f), old_package)
 
     def repackage(self):
-        old_package = self.get_old_package()
+        old_package = self.get_current_package_name()
         if old_package is not None and old_package != self.project.new_package:
             self.check_original_route(old_package)
             self.update_name(self.initial_folder, old_package, self.project.new_package)
@@ -101,7 +101,7 @@ class Android:
             print("Reusing old package name in Android!")
 
     def rename_app(self):
-        old_app_name = self.get_old_app_name()
+        old_app_name = self.get_current_app_name()
         if old_app_name is not None and old_app_name != self.project.new_app_name:
             self.update_name(self.initial_folder, old_app_name, self.project.new_app_name)
             print("✅ Rename Android app successfully!")
@@ -147,7 +147,7 @@ class Ios:
             os.sep + "Runner.xcodeproj" + os.sep + "project.pbxproj"
         self.info_file = p.project_path + os.sep + "ios" + os.sep + "Runner" + os.sep + "Info.plist"
 
-    def get_old_package(self):
+    def get_current_package_name(self):
         f = open(self.project_file, "r")
         file_text = f.read()
         f.close()
@@ -156,7 +156,7 @@ class Ios:
                 return line.strip().split(" = ")[1].strip().replace(";", "").replace(".staging", "")
         return None
 
-    def get_old_app_name(self):
+    def get_current_app_name(self):
         f = open(self.project_file, "r")
         file_text = f.read()
         f.close()
@@ -166,7 +166,7 @@ class Ios:
                     .replace(";", "").replace(" Staging", "").replace(" Production", "")
         return None
 
-    def get_old_project_name(self):
+    def get_current_project_name(self):
         f = open(self.info_file, "r")
         file_text = f.read()
         f.close()
@@ -194,7 +194,7 @@ class Ios:
             f.close()
 
     def repackage(self):
-        old_package = self.get_old_package()
+        old_package = self.get_current_package_name()
         if old_package is not None and old_package != self.project.new_package:
             self.replace_text_in_file(file_path=self.project_file, contain_text="PRODUCT_BUNDLE_IDENTIFIER",
                                       old_text=old_package, new_text=self.project.new_package)
@@ -205,7 +205,7 @@ class Ios:
             print("Reusing old package name in iOS!")
 
     def rename_app(self):
-        old_app_name = self.get_old_app_name()
+        old_app_name = self.get_current_app_name()
         if old_app_name is not None and old_app_name != self.project.new_app_name:
             self.replace_text_in_file(file_path=self.project_file, contain_text="APP_DISPLAY_NAME",
                                       old_text=old_app_name, new_text=self.project.new_app_name)
@@ -217,7 +217,7 @@ class Ios:
             print("Reusing old app name in iOS!")
 
     def rename_project(self):
-        old_project_name = self.get_old_project_name()
+        old_project_name = self.get_current_project_name()
         if old_project_name is not None and old_project_name != self.project.new_project_name:
             self.replace_text_in_file(file_path=self.project_file, contain_text=old_project_name,
                                       old_text=old_project_name, new_text=self.project.new_project_name)

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -6,29 +6,34 @@ import unittest
 
 from setup import Android, Project, Ios, Flutter
 
-project = Project()
-project.project_path = os.path.curdir
-project.new_package = 'com.example'
-project.new_app_name = ''
-project.new_project_name = 'example_project'
+expected_project_path = os.getenv("PROJECT_PATH") if bool(os.getenv("PROJECT_PATH")) else os.path.curdir + "/.template"
+expected_package_name = os.environ.get("PACKAGE_NAME") if bool(os.environ.get("PACKAGE_NAME")) else "co.nimblehq.flutter.template"
+expected_app_name = os.environ.get("APP_NAME") if bool(os.environ.get("APP_NAME")) else "Flutter Templates"
+expected_project_name = os.environ.get("PROJECT_NAME") if bool(os.environ.get("PROJECT_NAME")) else "flutter_templates"
+expected_app_version = os.environ.get("APP_VERSION") if bool(os.environ.get("APP_VERSION")) else "0.1.0"
+expected_build_number = os.environ.get("BUILD_NUMBER") if bool(os.environ.get("BUILD_NUMBER")) else "1"
 
-package_name = "co.nimblehq.flutter.template"
-project_name = "flutter_templates"
-app_name = "Flutter Templates"
-
+project = Project(
+    expected_project_path,
+    expected_package_name,
+    expected_app_name,
+    expected_project_name,
+    expected_app_version,
+    expected_build_number
+)
 
 class AndroidTest(unittest.TestCase):
     def setUp(self):
         self.android = Android(project)
 
     def test_get_old_package(self):
-        self.assertEqual(self.android.get_old_package(), package_name)
+        self.assertEqual(self.android.get_current_package_name(), expected_package_name)
 
     def test_get_old_app_name(self):
-        self.assertEqual(self.android.get_old_app_name(), app_name)
+        self.assertEqual(self.android.get_current_app_name(), expected_app_name)
 
     def test_check_original_route(self):
-        old_package = self.android.get_old_package()
+        old_package = self.android.get_current_package_name()
         self.assertEqual(self.android.check_original_route(old_package), None)
 
 
@@ -37,13 +42,13 @@ class IosTest(unittest.TestCase):
         self.ios = Ios(project)
 
     def test_get_old_package(self):
-        self.assertEqual(self.ios.get_old_package(), package_name)
+        self.assertEqual(self.ios.get_current_package_name(), expected_package_name)
 
     def test_get_old_app_name(self):
-        self.assertEqual(self.ios.get_old_app_name(), app_name)
+        self.assertEqual(self.ios.get_current_app_name(), expected_app_name)
 
     def test_get_old_project_name(self):
-        self.assertEqual(self.ios.get_old_project_name(), project_name)
+        self.assertEqual(self.ios.get_current_project_name(), expected_project_name)
 
 
 class FlutterTest(unittest.TestCase):
@@ -51,7 +56,7 @@ class FlutterTest(unittest.TestCase):
         self.flutter = Flutter(project)
 
     def test_get_old_project_name(self):
-        self.assertEqual(self.flutter.get_old_project_name(), project_name)
+        self.assertEqual(self.flutter.get_old_project_name(), expected_project_name)
 
 
 if __name__ == '__main__':

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -7,7 +7,7 @@ import unittest
 from setup import Android, Project, Ios, Flutter
 
 # After creating a new project, the new project will be created in the current directory.
-expected_project_path = os.environ.get("PROJECT_PATH").replace("/.template", "") if os.environ.get("RUNNING_TEST_MODE") == "1" else os.environ.get("PROJECT_PATH")
+expected_project_path = os.environ.get("PROJECT_PATH").replace("/.template", "") if os.environ.get("RUNNING_TEST_MODE") == "0" else os.environ.get("PROJECT_PATH")
 expected_package_name = os.environ.get("PACKAGE_NAME") if bool(os.environ.get("PACKAGE_NAME")) else "co.nimblehq.flutter.template"
 expected_app_name = os.environ.get("APP_NAME") if bool(os.environ.get("APP_NAME")) else "Flutter Templates"
 expected_project_name = os.environ.get("PROJECT_NAME") if bool(os.environ.get("PROJECT_NAME")) else "flutter_templates"

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -6,7 +6,8 @@ import unittest
 
 from setup import Android, Project, Ios, Flutter
 
-expected_project_path = os.getenv("PROJECT_PATH") if bool(os.getenv("PROJECT_PATH")) else os.path.curdir + "/.template"
+# After creating a new project, the new project will be created in the current directory.
+expected_project_path = os.environ.get("PROJECT_PATH").replace("/.template", "") if os.environ.get("RUNNING_TEST_MODE") == "1" else os.environ.get("PROJECT_PATH")
 expected_package_name = os.environ.get("PACKAGE_NAME") if bool(os.environ.get("PACKAGE_NAME")) else "co.nimblehq.flutter.template"
 expected_app_name = os.environ.get("APP_NAME") if bool(os.environ.get("APP_NAME")) else "Flutter Templates"
 expected_project_name = os.environ.get("PROJECT_NAME") if bool(os.environ.get("PROJECT_NAME")) else "flutter_templates"


### PR DESCRIPTION
https://github.com/nimblehq/flutter_templates/issues/56

## What happened 👀

After initializing the project by using init script, the test cases run failed but the project works without any issue. The issue might come from the test itself.

## Insight 📝

- We create one more env var `RUNNING_TEST_MODE` to separate to 2 cases:
  - Run `make test` independently. -> `.template` path is still kept in this case.
  - Run `make run` -> After init script successfully, `.template` path should be removed.

## Proof Of Work 📹

https://user-images.githubusercontent.com/60863885/166907360-b12ef4ff-3ced-4e1c-98d9-f8dac664b5d5.mov

