### PR TITLE
[#49] Fix: Bundle identifier does not allow underscore in iOS

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -195,9 +195,12 @@ class Ios:
 
     def repackage(self):
         old_package = self.get_current_package_name()
-        if old_package is not None and old_package != self.project.new_package:
+        # To follow iOS identifier rules, we need to replace underscore (_) with hyphen (-)
+        # Read more: https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleidentifier
+        new_package = self.project.new_package.replace("_", "-")
+        if old_package is not None and old_package != new_package:
             self.replace_text_in_file(file_path=self.project_file, contain_text="PRODUCT_BUNDLE_IDENTIFIER",
-                                      old_text=old_package, new_text=self.project.new_package)
+                                      old_text=old_package, new_text=new_package)
             print("✅ Update package name for iOS successfully!")
         elif old_package is None:
             print("❌ Bundle identifier not found in Runner.xcodeproj/project.pbxproj!")

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -43,7 +43,7 @@ class IosTest(unittest.TestCase):
         self.ios = Ios(project)
 
     def test_get_old_package(self):
-        self.assertEqual(self.ios.get_current_package_name(), expected_package_name)
+        self.assertEqual(self.ios.get_current_package_name(), expected_package_name.replace("_", "-"))
 
     def test_get_old_app_name(self):
         self.assertEqual(self.ios.get_current_app_name(), expected_app_name)


### PR DESCRIPTION
https://github.com/nimblehq/flutter_templates/issues/49

## What happened 👀

When initializing the project via script with the PACKAGE_NAME containing the underscore symbol _ (example: co.nimblehq.example.nimblehq_github), we are not able to create the development provisioning profile (to run app on the real iOS device). It is because the bundle identifier is invalid according to [CFBundleIdentifier](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleidentifier): The bundle ID string must contain only alphanumeric characters (A–Z, a–z, and 0–9), hyphens (-), and periods (.)

**NOTE**: Android accepts the underscore symbol.

## Insight 📝

n/a

## Proof Of Work 📹

https://user-images.githubusercontent.com/60863885/169260881-89449918-14cb-4434-abfc-ab757b59880e.mp4

