### PR TITLE
[#60] As a developer, I can have a CD process to build and deploy the iOS app to App Store

### DIFF
--- a/.github/workflows/ios_deploy_to_app_store.yml
+++ b/.github/workflows/ios_deploy_to_app_store.yml
@@ -1,0 +1,52 @@
+name: ios-deploy-to-app-store
+on:
+  # Trigger the workflow on push action
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+
+jobs:
+  build_and_upload_to_app_store:
+    name: Build And Upload iOS Application To AppStore
+    runs-on: macOS-latest
+    defaults:
+      run:
+        working-directory: .template
+    env:
+      TEAM_ID: ${{ secrets.TEAM_ID }}
+      FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
+      FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
+      FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
+      FASTLANE_SESSION: ${{ secrets.FASTLANE_SESSION }}
+      MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+      KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Install SSH key
+      uses: webfactory/ssh-agent@v0.4.1
+      with:
+        ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+    - uses: subosito/flutter-action@v1
+      with:
+        channel: 'stable'
+        flutter-version: '2.10.3'
+
+    - name: Get flutter dependencies
+      run: flutter pub get
+
+    - name: Run code generator
+      run: flutter packages pub run build_runner build --delete-conflicting-outputs
+
+    - name: Bundle install
+      run: cd ./ios && bundle install
+
+    - name: Pod install
+      run: cd ./ios && pod install
+
+    - name: Match AppStore
+      run: cd ./ios && bundle exec fastlane sync_appstore_staging_signing
+
+    - name: Deploy to AppStore
+      run: |
+        cd ./ios && bundle exec fastlane build_and_upload_app_store_connect_app

--- a/.template/.github/workflows/ios_deploy_to_app_store.yml
+++ b/.template/.github/workflows/ios_deploy_to_app_store.yml
@@ -1,8 +1,9 @@
 name: ios-deploy-to-app-store
 on:
   # Trigger the workflow on push action
-  pull_request:
-    types: [ opened, synchronize, reopened ]
+  push:
+    branches:
+      - develop
 
 jobs:
   build_and_upload_to_app_store:

--- a/.template/.github/workflows/ios_deploy_to_testflight.yml
+++ b/.template/.github/workflows/ios_deploy_to_testflight.yml
@@ -1,4 +1,4 @@
-name: ios-deployment
+name: ios-deploy-to-testflight
 on:
   # Trigger the workflow on push action
   push:

--- a/.template/ios/fastlane/Fastfile
+++ b/.template/ios/fastlane/Fastfile
@@ -68,6 +68,29 @@ platform :ios do
     )
   end
 
+  # AppStore
+
+  desc 'Build and upload Staging app to App Store Connect'
+  lane :build_and_upload_app_store_connect_app do
+    set_app_version
+    bump_build
+    builder.build_app_store(
+      Constants.SCHEME_NAME_STAGING,
+      Constants.PRODUCT_NAME_STAGING,
+      Constants.BUNDLE_ID_STAGING,
+      false
+    )
+    upload_build_to_app_store_connect
+  end
+
+  desc 'upload develop build to App Store Connect'
+  private_lane :upload_build_to_app_store_connect do
+    distribution_manager.upload_to_app_store_connect(
+      product_name: Constants.PRODUCT_NAME_STAGING,
+      bundle_identifier: Constants.BUNDLE_ID_STAGING
+    )
+  end
+
   # Private helper lanes
 
   desc 'check if any specific version number in build environment'

--- a/.template/ios/fastlane/Managers/DistributionManager.rb
+++ b/.template/ios/fastlane/Managers/DistributionManager.rb
@@ -14,4 +14,15 @@ class DistributionManager
       skip_waiting_for_build_processing: true
     )
   end
+
+  def upload_to_app_store_connect(product_name:, bundle_identifier:)
+    @fastlane.deliver(
+      ipa: "#{@build_path}/#{product_name}.ipa",
+      app_identifier: bundle_identifier,
+      force: true,
+      skip_metadata: true,
+      skip_screenshots: true,
+      run_precheck_before_submit: false
+    )
+  end
 end


### PR DESCRIPTION
https://github.com/nimblehq/flutter_templates/issues/60

## What happened 👀

As a developer, we need to prepare a CD process to build and deploy the staging iOS app to App Store.

## Insight 📝

n/a

## Proof Of Work 📹

The workflow is tested in CI: https://github.com/nimblehq/flutter_templates/runs/6705133545?check_suite_focus=true

The fastlane command is tested in local:
```
 ~/Desktop/nimble/github/flutter_templates/.template/ios  develop !5  bundle exec fastlane build_and_upload_app_store_connect_app                                                                                       1 ✘  1m 26s  15:11:50 
[✔] 🚀 
[15:13:16]: ------------------------------
[15:13:16]: --- Step: default_platform ---
[15:13:16]: ------------------------------
[15:13:16]: Driving the lane 'ios build_and_upload_app_store_connect_app' 🚀
[15:13:16]: --------------------------------
[15:13:16]: --- Step: ensure_bundle_exec ---
[15:13:16]: --------------------------------
[15:13:16]: Using bundled fastlane ✅
[15:13:16]: ------------------------------------------------
[15:13:16]: --- Step: Switch to ios set_app_version lane ---
[15:13:16]: ------------------------------------------------
[15:13:16]: Cruising over to lane 'ios set_app_version' 🚖
[15:13:16]: Cruising back to lane 'ios build_and_upload_app_store_connect_app' 🚘
[15:13:16]: -------------------------------------------
[15:13:16]: --- Step: Switch to ios bump_build lane ---
[15:13:16]: -------------------------------------------
[15:13:16]: Cruising over to lane 'ios bump_build' 🚖
[15:13:16]: ------------------------------------
[15:13:16]: --- Step: increment_build_number ---
[15:13:16]: ------------------------------------
Current version of project Runner is: 
    141

/Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios
[15:13:17]: $ cd /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios && agvtool new-version -all 142 && cd -
[15:13:17]: ▸ Setting version of project Runner to:
[15:13:17]: ▸ 142.
[15:13:17]: ▸ Also setting CFBundleVersion key (assuming it exists)
[15:13:17]: ▸ Updating CFBundleVersion in Info.plist(s)...
[15:13:17]: ▸ Updated CFBundleVersion in "Runner.xcodeproj/../Runner/Info.plist" to 142
[15:13:17]: ▸ /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios
[15:13:17]: Cruising back to lane 'ios build_and_upload_app_store_connect_app' 🚘
[15:13:17]: -----------------
[15:13:17]: --- Step: gym ---
[15:13:17]: -----------------
[15:13:17]: In the config file './fastlane/Gymfile' you have the line export_team_id, but didn't provide any value. Make sure to append a value right after the option name. Make sure to check the docs for more information
[15:13:17]: Successfully loaded '/Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/fastlane/Gymfile' 📄

+---------------------+---------------------+
| Detected Values from './fastlane/Gymfile' |
+---------------------+---------------------+
| clean               | true                |
| output_directory    | ./Build             |
| build_path          | ./Build             |
| derived_data_path   | ./DerivedData       |
+---------------------+---------------------+

[15:13:17]: Resolving Swift Package Manager dependencies...
[15:13:17]: $ xcodebuild -resolvePackageDependencies -workspace ./Runner.xcworkspace -scheme staging -derivedDataPath ./DerivedData
[15:13:17]: ▸ 2022-06-02 15:13:17.848 xcodebuild[31847:333437] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionSentinelHostApplications for extension Xcode.DebuggerFoundation.AppExtensionHosts.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
[15:13:17]: ▸ 2022-06-02 15:13:17.848 xcodebuild[31847:333437] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionPointIdentifierToBundleIdentifier for extension Xcode.DebuggerFoundation.AppExtensionToBundleIdentifierMap.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
[15:13:18]: ▸ Command line invocation:
[15:13:18]: ▸     /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -resolvePackageDependencies -workspace ./Runner.xcworkspace -scheme staging -derivedDataPath ./DerivedData
[15:13:18]: ▸ User defaults from command line:
[15:13:18]: ▸     IDEDerivedDataPathOverride = /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/DerivedData
[15:13:18]: ▸     IDEPackageSupportUseBuiltinSCM = YES
[15:13:18]: ▸ --- xcodebuild: WARNING: Using the first of multiple matching destinations:
[15:13:18]: ▸ { platform:macOS, arch:arm64, variant:Designed for [iPad,iPhone], id:00006000-001408420C29801E }
[15:13:18]: ▸ { platform:iOS, id:dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder, name:Any iOS Device }
[15:13:18]: ▸ { platform:iOS Simulator, id:dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder, name:Any iOS Simulator Device }
[15:13:18]: ▸ { platform:iOS Simulator, id:78EDFE02-C79B-4DE9-BD5B-5FA90EA6B747, OS:15.4, name:iPad (9th generation) }
[15:13:18]: ▸ { platform:iOS Simulator, id:078C7F39-56D5-4E78-B440-3D2CAF3BA9B1, OS:15.4, name:iPad Air (5th generation) }
[15:13:18]: ▸ { platform:iOS Simulator, id:FE5473ED-1262-4B09-A49B-28A8CD55596B, OS:15.4, name:iPad Pro (9.7-inch) }
[15:13:18]: ▸ { platform:iOS Simulator, id:A27864C6-F18A-44AF-8218-C992D1B64002, OS:15.4, name:iPad Pro (11-inch) (3rd generation) }
[15:13:18]: ▸ { platform:iOS Simulator, id:3485133E-954F-46A4-B720-CABBDFE5EECD, OS:15.4, name:iPad Pro (12.9-inch) (5th generation) }
[15:13:18]: ▸ { platform:iOS Simulator, id:BC5DE5CA-05AD-4DD2-A7F9-1732700F355F, OS:15.4, name:iPad mini (6th generation) }
[15:13:18]: ▸ { platform:iOS Simulator, id:D2B1911E-AC66-4322-BFFD-08EA4F517350, OS:15.4, name:iPhone 8 }
[15:13:18]: ▸ { platform:iOS Simulator, id:44DB4E16-ECB7-4C36-A970-FF3829601A6D, OS:15.4, name:iPhone 8 Plus }
[15:13:18]: ▸ { platform:iOS Simulator, id:0D70BEBF-A2B1-415F-ADF4-2F6EDB6B2084, OS:15.4, name:iPhone 11 }
[15:13:18]: ▸ { platform:iOS Simulator, id:A193CD3A-EA55-454E-A522-3C686A5989E4, OS:15.4, name:iPhone 11 Pro }
[15:13:18]: ▸ { platform:iOS Simulator, id:A0E4BECE-8B70-48F8-B2B5-19AC786CF0F9, OS:15.4, name:iPhone 11 Pro Max }
[15:13:18]: ▸ { platform:iOS Simulator, id:FD8FEC80-4966-4D13-9058-709D6B25AD6E, OS:15.4, name:iPhone 12 }
[15:13:18]: ▸ { platform:iOS Simulator, id:61EC9399-75D0-4DA1-A75E-62321990A60D, OS:15.4, name:iPhone 12 Pro }
[15:13:18]: ▸ { platform:iOS Simulator, id:4E049E86-16D8-4918-80E8-E87B8E69B081, OS:15.4, name:iPhone 12 Pro Max }
[15:13:18]: ▸ { platform:iOS Simulator, id:CF612527-9A7A-40AC-BBA0-C97292D6944C, OS:15.4, name:iPhone 12 mini }
[15:13:18]: ▸ { platform:iOS Simulator, id:C2C1E658-A57D-4F17-AE52-C9D15CC7F2FB, OS:15.4, name:iPhone 13 }
[15:13:18]: ▸ { platform:iOS Simulator, id:0AB9BAA7-94F3-44BF-9E2C-E7AEAA083814, OS:15.4, name:iPhone 13 Pro }
[15:13:18]: ▸ { platform:iOS Simulator, id:75FC7BF3-439E-4D6F-8DCB-1267993A8015, OS:15.4, name:iPhone 13 Pro Max }
[15:13:18]: ▸ { platform:iOS Simulator, id:57356965-C437-469F-9D27-DCF9B63E5059, OS:15.4, name:iPhone 13 mini }
[15:13:18]: ▸ { platform:iOS Simulator, id:2AF61DD9-DDB7-4BF1-A1BD-61F34C39A400, OS:15.4, name:iPhone SE (3rd generation) }
[15:13:18]: ▸ { platform:iOS Simulator, id:4C341239-DF90-41D7-84D1-1DC2F677D2A8, OS:15.4, name:iPod touch (7th generation) }
[15:13:18]: ▸ resolved source packages: 
[15:13:18]: $ xcodebuild -showBuildSettings -workspace ./Runner.xcworkspace -scheme staging -derivedDataPath ./DerivedData
2022-06-02 15:13:18.759 xcodebuild[31854:333592] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionSentinelHostApplications for extension Xcode.DebuggerFoundation.AppExtensionHosts.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
2022-06-02 15:13:18.760 xcodebuild[31854:333592] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionPointIdentifierToBundleIdentifier for extension Xcode.DebuggerFoundation.AppExtensionToBundleIdentifierMap.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
--- xcodebuild: WARNING: Using the first of multiple matching destinations:
{ platform:macOS, arch:arm64, variant:Designed for [iPad,iPhone], id:00006000-001408420C29801E }
{ platform:iOS, id:dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder, name:Any iOS Device }
{ platform:iOS Simulator, id:dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder, name:Any iOS Simulator Device }
{ platform:iOS Simulator, id:78EDFE02-C79B-4DE9-BD5B-5FA90EA6B747, OS:15.4, name:iPad (9th generation) }
{ platform:iOS Simulator, id:078C7F39-56D5-4E78-B440-3D2CAF3BA9B1, OS:15.4, name:iPad Air (5th generation) }
{ platform:iOS Simulator, id:FE5473ED-1262-4B09-A49B-28A8CD55596B, OS:15.4, name:iPad Pro (9.7-inch) }
{ platform:iOS Simulator, id:A27864C6-F18A-44AF-8218-C992D1B64002, OS:15.4, name:iPad Pro (11-inch) (3rd generation) }
{ platform:iOS Simulator, id:3485133E-954F-46A4-B720-CABBDFE5EECD, OS:15.4, name:iPad Pro (12.9-inch) (5th generation) }
{ platform:iOS Simulator, id:BC5DE5CA-05AD-4DD2-A7F9-1732700F355F, OS:15.4, name:iPad mini (6th generation) }
{ platform:iOS Simulator, id:D2B1911E-AC66-4322-BFFD-08EA4F517350, OS:15.4, name:iPhone 8 }
{ platform:iOS Simulator, id:44DB4E16-ECB7-4C36-A970-FF3829601A6D, OS:15.4, name:iPhone 8 Plus }
{ platform:iOS Simulator, id:0D70BEBF-A2B1-415F-ADF4-2F6EDB6B2084, OS:15.4, name:iPhone 11 }
{ platform:iOS Simulator, id:A193CD3A-EA55-454E-A522-3C686A5989E4, OS:15.4, name:iPhone 11 Pro }
{ platform:iOS Simulator, id:A0E4BECE-8B70-48F8-B2B5-19AC786CF0F9, OS:15.4, name:iPhone 11 Pro Max }
{ platform:iOS Simulator, id:FD8FEC80-4966-4D13-9058-709D6B25AD6E, OS:15.4, name:iPhone 12 }
{ platform:iOS Simulator, id:61EC9399-75D0-4DA1-A75E-62321990A60D, OS:15.4, name:iPhone 12 Pro }
{ platform:iOS Simulator, id:4E049E86-16D8-4918-80E8-E87B8E69B081, OS:15.4, name:iPhone 12 Pro Max }
{ platform:iOS Simulator, id:CF612527-9A7A-40AC-BBA0-C97292D6944C, OS:15.4, name:iPhone 12 mini }
{ platform:iOS Simulator, id:C2C1E658-A57D-4F17-AE52-C9D15CC7F2FB, OS:15.4, name:iPhone 13 }
{ platform:iOS Simulator, id:0AB9BAA7-94F3-44BF-9E2C-E7AEAA083814, OS:15.4, name:iPhone 13 Pro }
{ platform:iOS Simulator, id:75FC7BF3-439E-4D6F-8DCB-1267993A8015, OS:15.4, name:iPhone 13 Pro Max }
{ platform:iOS Simulator, id:57356965-C437-469F-9D27-DCF9B63E5059, OS:15.4, name:iPhone 13 mini }
{ platform:iOS Simulator, id:2AF61DD9-DDB7-4BF1-A1BD-61F34C39A400, OS:15.4, name:iPhone SE (3rd generation) }
{ platform:iOS Simulator, id:4C341239-DF90-41D7-84D1-1DC2F677D2A8, OS:15.4, name:iPod touch (7th generation) }
[15:13:19]: Detected provisioning profile mapping: {:""=>"match AppStore co.nimblehq.flutter.template.staging", :"co.nimblehq.flutter.template.staging"=>"match AppStore co.nimblehq.flutter.template.staging"}

+--------------------------------------------------------------------------+-----------------------------------------------------+
|                                                    Summary for gym 2.205.1                                                     |
+--------------------------------------------------------------------------+-----------------------------------------------------+
| scheme                                                                   | staging                                             |
| export_method                                                            | app-store                                           |
| export_options.provisioningProfiles.                                     | match AppStore co.nimblehq.flutter.template.staging |
| export_options.provisioningProfiles.co.nimblehq.flutter.template.staging | match AppStore co.nimblehq.flutter.template.staging |
| include_bitcode                                                          | false                                               |
| output_name                                                              | Flutter Template Staging                            |
| workspace                                                                | ./Runner.xcworkspace                                |
| clean                                                                    | true                                                |
| output_directory                                                         | ./Build                                             |
| silent                                                                   | false                                               |
| skip_package_ipa                                                         | false                                               |
| skip_package_pkg                                                         | false                                               |
| build_path                                                               | ./Build                                             |
| derived_data_path                                                        | ./DerivedData                                       |
| result_bundle                                                            | false                                               |
| buildlog_path                                                            | ~/Library/Logs/gym                                  |
| destination                                                              | generic/platform=iOS                                |
| xcodebuild_formatter                                                     | xcpretty                                            |
| skip_profile_detection                                                   | false                                               |
| xcodebuild_command                                                       | xcodebuild                                          |
| skip_package_dependencies_resolution                                     | false                                               |
| disable_package_automatic_updates                                        | false                                               |
| use_system_scm                                                           | false                                               |
| xcode_path                                                               | /Applications/Xcode.app                             |
+--------------------------------------------------------------------------+-----------------------------------------------------+

[15:13:19]: $ set -o pipefail && xcodebuild -workspace ./Runner.xcworkspace -scheme staging -derivedDataPath ./DerivedData -destination 'generic/platform=iOS' -archivePath ./Build/Flutter\ Template\ Staging\ 2022-06-02\ 15.13.19.xcarchive clean archive | tee /Users/tranmanh/Library/Logs/gym/Runner-staging.log | xcpretty
[15:13:20]: ▸ 2022-06-02 15:13:20.199 xcodebuild[31879:333701] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionSentinelHostApplications for extension Xcode.DebuggerFoundation.AppExtensionHosts.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
[15:13:20]: ▸ 2022-06-02 15:13:20.199 xcodebuild[31879:333701] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionPointIdentifierToBundleIdentifier for extension Xcode.DebuggerFoundation.AppExtensionToBundleIdentifierMap.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
[15:13:21]: ▸ Clean Succeeded
[15:13:22]: ▸ Processing package_info_plus-Info.plist
[15:13:22]: ▸ Copying FLTPackageInfoPlusPlugin.h
[15:13:22]: ▸ Copying package_info_plus-umbrella.h
[15:13:22]: ▸ Processing flutter_config-Info.plist
[15:13:22]: ▸ Copying flutter_config-umbrella.h
[15:13:22]: ▸ Copying FlutterConfigPlugin.h
[15:13:22]: ▸ Processing integration_test-Info.plist
[15:13:22]: ▸ Copying integration_test-umbrella.h
[15:13:22]: ▸ Copying IntegrationTestPlugin.h
[15:13:22]: ▸ Copying IntegrationTestIosTest.h
[15:13:22]: ▸ Compiling package_info_plus-dummy.m
[15:13:22]: ▸ Compiling FLTPackageInfoPlusPlugin.m
[15:13:22]: ▸ Compiling FLTPackageInfoPlusPlugin.m
[15:13:22]: ▸ Compiling package_info_plus-dummy.m
[15:13:22]: ▸ Compiling package_info_plus_vers.c
[15:13:22]: ▸ Compiling package_info_plus_vers.c
[15:13:22]: ▸ Compiling integration_test-dummy.m
[15:13:22]: ▸ Compiling IntegrationTestPlugin.m
[15:13:22]: ▸ Compiling integration_test_vers.c
[15:13:22]: ▸ Compiling IntegrationTestIosTest.m
[15:13:22]: ▸ Compiling integration_test_vers.c
[15:13:22]: ▸ Compiling integration_test-dummy.m
[15:13:23]: ▸ Compiling IntegrationTestPlugin.m
[15:13:23]: ▸ Compiling IntegrationTestIosTest.m
[15:13:23]: ▸ Running script '[CP-User] Config codegen'
[15:13:23]: ▸ Linking package_info_plus
[15:13:23]: ▸ Linking package_info_plus
[15:13:23]: ▸ Linking integration_test
[15:13:23]: ▸ Linking integration_test
[15:13:23]: ▸ Generating 'package_info_plus.framework.dSYM'
[15:13:23]: ▸ Generating 'integration_test.framework.dSYM'
[15:13:23]: ▸ Compiling flutter_config-dummy.m
[15:13:23]: ▸ Compiling GeneratedDotEnv.m
[15:13:23]: ▸ Compiling FlutterConfigPlugin.m
[15:13:23]: ▸ Compiling flutter_config-dummy.m
[15:13:23]: ▸ Compiling GeneratedDotEnv.m
[15:13:23]: ▸ Compiling flutter_config_vers.c
[15:13:23]: ▸ Compiling flutter_config_vers.c
[15:13:23]: ▸ Compiling FlutterConfigPlugin.m
[15:13:23]: ▸ Touching package_info_plus.framework (in target 'package_info_plus' from project 'Pods')
[15:13:23]: ▸ Touching integration_test.framework (in target 'integration_test' from project 'Pods')
[15:13:23]: ▸ Linking flutter_config
[15:13:23]: ▸ Linking flutter_config
[15:13:23]: ▸ Generating 'flutter_config.framework.dSYM'
[15:13:23]: ▸ Touching flutter_config.framework (in target 'flutter_config' from project 'Pods')
[15:13:23]: ▸ Processing Pods-Runner-Info.plist
[15:13:23]: ▸ Copying Pods-Runner-umbrella.h
[15:13:23]: ▸ Compiling Pods-Runner-dummy.m
[15:13:23]: ▸ Compiling Pods-Runner-dummy.m
[15:13:23]: ▸ Compiling Pods_Runner_vers.c
[15:13:23]: ▸ Compiling Pods_Runner_vers.c
[15:13:23]: ▸ Touching Pods_Runner.framework (in target 'Pods-Runner' from project 'Pods')
[15:13:23]: ▸ Running script '[CP] Check Pods Manifest.lock'
[15:13:23]: ▸ Running script 'Run Script'
[15:13:36]: ▸ Compiling AppDelegate.swift
[15:13:37]: ▸ Compiling AppDelegate.swift
[15:13:37]: ▸ Compiling Runner_vers.c
[15:13:37]: ▸ Compiling Runner_vers.c
[15:13:37]: ▸ Compiling GeneratedPluginRegistrant.m
[15:13:37]: ▸ Compiling GeneratedPluginRegistrant.m
[15:13:37]: ▸ Linking Runner
[15:13:37]: ▸ Linking Runner
[15:13:37]: ▸ Copying AppFrameworkInfo.plist
[15:13:37]: ▸ Compiling Main.storyboard
[15:13:38]: ▸ Compiling LaunchScreen.storyboard
[15:13:38]: ▸ Processing Info.plist
[15:13:38]: ▸ Running script 'Thin Binary'
[15:13:39]: ▸ Generating 'Runner.app.dSYM'
[15:13:39]: ▸ Running script '[CP] Embed Pods Frameworks'
[15:13:41]: ▸ Touching Runner.app (in target 'Runner' from project 'Runner')
[15:13:41]: ▸     no rule to process file '/Users/tranmanh/.pub-cache/hosted/pub.dartlang.org/flutter_config-2.0.0/ios/Classes/BuildDotenvConfig.rb' of type 'text.script.ruby' for architecture 'arm64' (in target 'flutter_config' from project 'Pods')
[15:13:41]: ▸     no rule to process file '/Users/tranmanh/.pub-cache/hosted/pub.dartlang.org/flutter_config-2.0.0/ios/Classes/BuildXCConfig.rb' of type 'text.script.ruby' for architecture 'arm64' (in target 'flutter_config' from project 'Pods')
[15:13:41]: ▸     no rule to process file '/Users/tranmanh/.pub-cache/hosted/pub.dartlang.org/flutter_config-2.0.0/ios/Classes/ReadDotEnv.rb' of type 'text.script.ruby' for architecture 'arm64' (in target 'flutter_config' from project 'Pods')
[15:13:41]: ▸     no rule to process file '/Users/tranmanh/.pub-cache/hosted/pub.dartlang.org/flutter_config-2.0.0/ios/Classes/BuildDotenvConfig.rb' of type 'text.script.ruby' for architecture 'armv7' (in target 'flutter_config' from project 'Pods')
[15:13:41]: ▸     no rule to process file '/Users/tranmanh/.pub-cache/hosted/pub.dartlang.org/flutter_config-2.0.0/ios/Classes/BuildXCConfig.rb' of type 'text.script.ruby' for architecture 'armv7' (in target 'flutter_config' from project 'Pods')
[15:13:41]: ▸     no rule to process file '/Users/tranmanh/.pub-cache/hosted/pub.dartlang.org/flutter_config-2.0.0/ios/Classes/ReadDotEnv.rb' of type 'text.script.ruby' for architecture 'armv7' (in target 'flutter_config' from project 'Pods')
[15:13:41]: ▸ Archive Succeeded
[15:13:41]: Generated plist file with the following values:
[15:13:41]: ▸ -----------------------------------------
[15:13:41]: ▸ {
[15:13:41]: ▸   "provisioningProfiles": {
[15:13:41]: ▸     "": "match AppStore co.nimblehq.flutter.template.staging",
[15:13:41]: ▸     "co.nimblehq.flutter.template.staging": "match AppStore co.nimblehq.flutter.template.staging"
[15:13:41]: ▸   },
[15:13:41]: ▸   "method": "app-store",
[15:13:41]: ▸   "uploadBitcode": false,
[15:13:41]: ▸   "signingStyle": "manual"
[15:13:41]: ▸ }
[15:13:41]: ▸ -----------------------------------------
[15:13:41]: $ /usr/bin/xcrun /Users/tranmanh/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/fastlane-2.205.1/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh -exportArchive -exportOptionsPlist '/var/folders/wx/8js354d905l121_3gm9sq0bw0000gn/T/gym_config20220602-31761-wknm22.plist' -archivePath ./Build/Flutter\ Template\ Staging\ 2022-06-02\ 15.13.19.xcarchive -exportPath '/var/folders/wx/8js354d905l121_3gm9sq0bw0000gn/T/gym_output20220602-31761-is48h7' 
[15:13:51]: Mapping dSYM(s) using generated BCSymbolMaps
[15:13:51]: $ dsymutil --symbol-map /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter\ Template\ Staging\ 2022-06-02\ 15.13.19.xcarchive/BCSymbolMaps /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter\ Template\ Staging\ 2022-06-02\ 15.13.19.xcarchive/dSYMs/Runner.app.dSYM
warning: /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter Template Staging 2022-06-02 15.13.19.xcarchive/BCSymbolMaps/Runner-armv7.bcsymbolmap: No such file or directory: not unobfuscating.
warning: /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter Template Staging 2022-06-02 15.13.19.xcarchive/BCSymbolMaps/Runner-arm64.bcsymbolmap: No such file or directory: not unobfuscating.
[15:13:51]: $ dsymutil --symbol-map /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter\ Template\ Staging\ 2022-06-02\ 15.13.19.xcarchive/BCSymbolMaps /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter\ Template\ Staging\ 2022-06-02\ 15.13.19.xcarchive/dSYMs/Runner.app.dSYM
warning: /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter Template Staging 2022-06-02 15.13.19.xcarchive/BCSymbolMaps/Runner-armv7.bcsymbolmap: No such file or directory: not unobfuscating.
warning: /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter Template Staging 2022-06-02 15.13.19.xcarchive/BCSymbolMaps/Runner-arm64.bcsymbolmap: No such file or directory: not unobfuscating.
[15:13:51]: $ dsymutil --symbol-map /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter\ Template\ Staging\ 2022-06-02\ 15.13.19.xcarchive/BCSymbolMaps/65785EC1-FFD5-37DC-A0AD-BC227D9D1A88.bcsymbolmap /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter\ Template\ Staging\ 2022-06-02\ 15.13.19.xcarchive/dSYMs/flutter_config.framework.dSYM
[15:13:51]: $ dsymutil --symbol-map /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter\ Template\ Staging\ 2022-06-02\ 15.13.19.xcarchive/BCSymbolMaps/A04B0996-A533-3053-B259-93F5C2342E81.bcsymbolmap /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter\ Template\ Staging\ 2022-06-02\ 15.13.19.xcarchive/dSYMs/flutter_config.framework.dSYM
[15:13:51]: $ dsymutil --symbol-map /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter\ Template\ Staging\ 2022-06-02\ 15.13.19.xcarchive/BCSymbolMaps/E5B9267B-B0B4-3A60-8EF1-6836391D3DFE.bcsymbolmap /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter\ Template\ Staging\ 2022-06-02\ 15.13.19.xcarchive/dSYMs/integration_test.framework.dSYM
[15:13:51]: $ dsymutil --symbol-map /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter\ Template\ Staging\ 2022-06-02\ 15.13.19.xcarchive/BCSymbolMaps/B65506E3-725E-351E-99BC-81000B3C15CB.bcsymbolmap /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter\ Template\ Staging\ 2022-06-02\ 15.13.19.xcarchive/dSYMs/integration_test.framework.dSYM
[15:13:51]: $ dsymutil --symbol-map /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter\ Template\ Staging\ 2022-06-02\ 15.13.19.xcarchive/BCSymbolMaps/36E8AE8A-3F29-329D-AA30-83840D23887A.bcsymbolmap /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter\ Template\ Staging\ 2022-06-02\ 15.13.19.xcarchive/dSYMs/package_info_plus.framework.dSYM
[15:13:51]: $ dsymutil --symbol-map /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter\ Template\ Staging\ 2022-06-02\ 15.13.19.xcarchive/BCSymbolMaps/55BE4CC2-123B-3B33-8C83-B2A20990C422.bcsymbolmap /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter\ Template\ Staging\ 2022-06-02\ 15.13.19.xcarchive/dSYMs/package_info_plus.framework.dSYM
[15:13:51]: Compressing 4 dSYM(s)
[15:13:51]: $ cd '/Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter Template Staging 2022-06-02 15.13.19.xcarchive/dSYMs' && zip -r '/Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter Template Staging.app.dSYM.zip' *.dSYM
[15:13:51]: ▸ updating: Runner.app.dSYM/ (stored 0%)
[15:13:51]: ▸ updating: Runner.app.dSYM/Contents/ (stored 0%)
[15:13:51]: ▸ updating: Runner.app.dSYM/Contents/Resources/ (stored 0%)
[15:13:51]: ▸ updating: Runner.app.dSYM/Contents/Resources/DWARF/ (stored 0%)
[15:13:51]: ▸ updating: Runner.app.dSYM/Contents/Resources/DWARF/Runner (deflated 57%)
[15:13:51]: ▸ updating: Runner.app.dSYM/Contents/Info.plist (deflated 51%)
[15:13:51]: ▸ updating: flutter_config.framework.dSYM/ (stored 0%)
[15:13:51]: ▸ updating: flutter_config.framework.dSYM/Contents/ (stored 0%)
[15:13:51]: ▸ updating: flutter_config.framework.dSYM/Contents/Resources/ (stored 0%)
[15:13:51]: ▸ updating: flutter_config.framework.dSYM/Contents/Resources/DWARF/ (stored 0%)
[15:13:51]: ▸ updating: flutter_config.framework.dSYM/Contents/Resources/DWARF/flutter_config (deflated 60%)
[15:13:51]: ▸ updating: flutter_config.framework.dSYM/Contents/Info.plist (deflated 52%)
[15:13:51]: ▸ updating: integration_test.framework.dSYM/ (stored 0%)
[15:13:51]: ▸ updating: integration_test.framework.dSYM/Contents/ (stored 0%)
[15:13:51]: ▸ updating: integration_test.framework.dSYM/Contents/Resources/ (stored 0%)
[15:13:51]: ▸ updating: integration_test.framework.dSYM/Contents/Resources/DWARF/ (stored 0%)
[15:13:51]: ▸ updating: integration_test.framework.dSYM/Contents/Resources/DWARF/integration_test (deflated 60%)
[15:13:51]: ▸ updating: integration_test.framework.dSYM/Contents/Info.plist (deflated 52%)
[15:13:51]: ▸ updating: package_info_plus.framework.dSYM/ (stored 0%)
[15:13:51]: ▸ updating: package_info_plus.framework.dSYM/Contents/ (stored 0%)
[15:13:51]: ▸ updating: package_info_plus.framework.dSYM/Contents/Resources/ (stored 0%)
[15:13:51]: ▸ updating: package_info_plus.framework.dSYM/Contents/Resources/DWARF/ (stored 0%)
[15:13:51]: ▸ updating: package_info_plus.framework.dSYM/Contents/Resources/DWARF/package_info_plus (deflated 60%)
[15:13:51]: ▸ updating: package_info_plus.framework.dSYM/Contents/Info.plist (deflated 52%)

[15:13:51]: Successfully exported and compressed dSYM file
[15:13:51]: Successfully exported and signed the ipa file:
[15:13:51]: /Users/tranmanh/Desktop/nimble/github/flutter_templates/.template/ios/Build/Flutter Template Staging.ipa
[15:13:51]: ------------------------------------------------------------------
[15:13:51]: --- Step: Switch to ios upload_build_to_app_store_connect lane ---
[15:13:51]: ------------------------------------------------------------------
[15:13:51]: Cruising over to lane 'ios upload_build_to_app_store_connect' 🚖
[15:13:51]: ---------------------
[15:13:51]: --- Step: deliver ---
[15:13:51]: ---------------------
[15:13:51]: To not be asked about this value, you can specify it using 'username'
[15:13:51]: Your Apple ID Username: manh@nimblehq.co
[15:13:57]: Login to App Store Connect (manh@nimblehq.co)
[15:14:01]: Login successful

+--------------------------------------+--------------------------------------+
|                           deliver 2.205.1 Summary                           |
+--------------------------------------+--------------------------------------+
| ipa                                  | ./Build/Flutter Template Staging.ipa |
| app_identifier                       | co.nimblehq.flutter.template.staging |
| force                                | true                                 |
| skip_metadata                        | true                                 |
| skip_screenshots                     | true                                 |
| run_precheck_before_submit           | false                                |
| username                             | manh@nimblehq.co                     |
| screenshots_path                     | ./fastlane/screenshots               |
| metadata_path                        | ./fastlane/metadata                  |
| app_version                          | 0.8.0                                |
| platform                             | ios                                  |
| edit_live                            | false                                |
| use_live_version                     | false                                |
| skip_binary_upload                   | false                                |
| skip_app_version_update              | false                                |
| overwrite_screenshots                | false                                |
| sync_screenshots                     | false                                |
| submit_for_review                    | false                                |
| reject_if_possible                   | false                                |
| phased_release                       | false                                |
| reset_ratings                        | false                                |
| precheck_default_rule_level          | warn                                 |
| ignore_language_directory_validation | false                                |
| precheck_include_in_app_purchases    | true                                 |
+--------------------------------------+--------------------------------------+

[15:14:02]: Making sure the latest version on App Store Connect matches '0.8.0'...
[15:14:03]: '0.8.0' is the latest version on App Store Connect
[15:14:03]: Uploading binary to App Store Connect
[15:14:05]: Going to upload updated app to App Store Connect
[15:14:05]: This might take a few minutes. Please don't interrupt the script.
[15:15:04]: iTunes Transporter successfully finished its job
[15:15:04]: ------------------------------------------------------------------------------------------------------------------
[15:15:04]: --- Successfully uploaded package to App Store Connect. It might take a few minutes until it's visible online. ---
[15:15:04]: ------------------------------------------------------------------------------------------------------------------
[15:15:04]: Finished the upload to App Store Connect
[15:15:04]: Cruising back to lane 'ios build_and_upload_app_store_connect_app' 🚘

+------+------------------------------------------------------+-------------+
|                             fastlane summary                              |
+------+------------------------------------------------------+-------------+
| Step | Action                                               | Time (in s) |
+------+------------------------------------------------------+-------------+
| 1    | default_platform                                     | 0           |
| 2    | ensure_bundle_exec                                   | 0           |
| 3    | Switch to ios set_app_version lane                   | 0           |
| 4    | Switch to ios bump_build lane                        | 0           |
| 5    | increment_build_number                               | 0           |
| 6    | gym                                                  | 34          |
| 7    | Switch to ios upload_build_to_app_store_connect lane | 0           |
| 8    | deliver                                              | 72          |
+------+------------------------------------------------------+-------------+

[15:15:04]: fastlane.tools finished successfully 🎉

#######################################################################
# fastlane 2.206.2 is available. You are on 2.205.1.
# You should use the latest version.
# Please update using `bundle update fastlane`.
#######################################################################

2.206.2 Improvements
* [Fastlane.swift] fix compile issue with argumentProcessor (#20318) via Josh Holtz (@joshdholtz)
* [Fastlane.Swift] Use ArgumentProcessor port to start fastlane socket_server (#20176) via Sven Tiigi (@SvenTiigi)
* [pem] fixed "\x82" from ASCII-8BIT to UTF-8 when saving .p12 files to disk (#20317) via Roger Oba (@rogerluan)
* [fastlane] fix a grammatical mistake when prompting which lane to run (#20307) via kamimi01 (@kamimi01)
* [fastlane][tests] add tests for CLIToolsDistributor (#20315) via Lukasz Grabowski (@lucgrabowski)

2.206.1 Hot fix
* [regression][fastlane] fixed fastlane command issue when tool name not provided (#20295) via Manish Rathi (@crazymanish)
* [aciton][import_from_git] fix/import from git spec fail with non master default branch (#20297) via Jerome Lacoste (@lacostej)

2.206.0 Improvements
* [match] add support for Developer ID certificates from G2 Sub-CA (#20145) via Frederik Seiffert (@triplef)
* [spaceship] add ability to invite a single TestFlight user (#20112) via Lucas (@LcTwisk)
* [deliver] add `verify_only` option to deliver (#20247) via Pol Piella (@pol-piella)
* [scan] fix scan failing to return results when there are test failures (#20237) via Mahmood Tahir (@tahirmt)
* [docs] remove named parameter from `create_capability` example. (#20197) via Trent Kocurek (@t2)
* [spaceship] fix creation App Store Connect API authorization token (#20206) via Yuya Oka (@nnsnodnb)
* [match] add option to skip google account confirmation (#20223) via Tim Sneed (@trsneed)
* [aciton][setup_ci] added timeout param into setup_ci (#20211) via javigines (@javigines)
* [action][danger] add GitHub Enterprise flags (#20216) via Alexander Weiß (@alexanderwe)
* [fastlane] allows aliased tool names (build_app, sync_code_signing, etc) to run from CLI (#20287) via Josh Holtz (@joshdholtz)
* [spaceship] update buildDeliveries request to use app id in path (#20268) via Lukasz Grabowski (@lucgrabowski)
* [spaceship] update `Spaceship::ConnectAPI::User model` to include `delete!` method (#20251) via Liam Nichols (@liamnichols)
* [infra] changelog will now show github usernames which makes contributors stand out more in releases (#20214) via Josh Holtz (@joshdholtz)

To see all new releases, open https://github.com/fastlane/fastlane/releases

Please update using `bundle update fastlane`
```

