### PR TITLE
[#89] Add base use cases

### DIFF
--- a/.template/lib/usecases/base/base_use_case.dart
+++ b/.template/lib/usecases/base/base_use_case.dart
@@ -1,0 +1,17 @@
+part 'use_case_result.dart';
+
+abstract class BaseUseCase<T extends Result> {
+  const BaseUseCase();
+}
+
+abstract class UseCase<T, P> extends BaseUseCase<Result<T>> {
+  const UseCase() : super();
+
+  Future<Result<T>> call(P params);
+}
+
+abstract class NoParamsUseCase<T> extends BaseUseCase<Result<T>> {
+  const NoParamsUseCase() : super();
+
+  Future<Result<T>> call();
+}

--- a/.template/lib/usecases/base/use_case_result.dart
+++ b/.template/lib/usecases/base/use_case_result.dart
@@ -1,0 +1,23 @@
+part of 'base_use_case.dart';
+
+abstract class Result<T> {
+  Result._();
+}
+
+class Success<T> extends Result<T> {
+  final T value;
+
+  Success(this.value) : super._();
+}
+
+class UseCaseException implements Exception {
+  final dynamic actualException;
+
+  UseCaseException(this.actualException);
+}
+
+class Failed<T> extends Result<T> {
+  final UseCaseException exception;
+
+  Failed(this.exception) : super._();
+}


### PR DESCRIPTION
https://github.com/nimblehq/flutter_templates/issues/89

## What happened 👀

To reduce the effort of creating the base use cases when initializing a project, the base use cases should be ready at the template level.

## Insight 📝

n/a

## Proof Of Work 📹

n/a
