### PR TITLE
[Hotfix] Can not build generated project from release 1.3.0

### DIFF
--- a/.template/lib/di/interceptor/app_interceptor.dart
+++ b/.template/lib/di/interceptor/app_interceptor.dart
@@ -4,8 +4,12 @@ import 'package:dio/dio.dart';
 
 class AppInterceptor extends Interceptor {
   final bool _requireAuthenticate;
+  final Dio _dio;
 
-  AppInterceptor(this._requireAuthenticate);
+  AppInterceptor(
+    this._requireAuthenticate,
+    this._dio,
+  );
 
   @override
   Future onRequest(

--- a/.template/lib/di/provider/dio_provider.dart
+++ b/.template/lib/di/provider/dio_provider.dart
@@ -15,7 +15,10 @@ class DioProvider {
 
   Dio _createDio({bool requireAuthenticate = false}) {
     final dio = Dio();
-    final appInterceptor = AppInterceptor(requireAuthenticate);
+    final appInterceptor = AppInterceptor(
+      requireAuthenticate,
+      dio,
+    );
     final interceptors = <Interceptor>[];
     interceptors.add(appInterceptor);
     if (!kReleaseMode) {

--- a/.template/lib/utils/wrappers/permission_wrapper.dart
+++ b/.template/lib/utils/wrappers/permission_wrapper.dart
@@ -1,4 +1,3 @@
-import 'package:injectable/injectable.dart';
 import 'package:permission_handler/permission_handler.dart'
     as permission_handler;
 
@@ -10,7 +9,6 @@ abstract class PermissionWrapper {
   Future<bool> isCameraPermissionPermanentlyDenied();
 }
 
-@Singleton(as: PermissionWrapper)
 class PermissionWrapperImpl extends PermissionWrapper {
   @override
   Future<bool> requestCameraPermission() {

--- a/.template/pubspec.yaml
+++ b/.template/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.3.1+12
+version: 1.3.1+13
 
 environment:
   sdk: ">=2.17.5 <3.0.0"

--- a/.template/pubspec.yaml
+++ b/.template/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.3.0+12
+version: 1.3.1+12
 
 environment:
   sdk: ">=2.17.5 <3.0.0"


### PR DESCRIPTION
## What happened 👀

The generated project can't run because of broken code.

![image](https://user-images.githubusercontent.com/16315358/210686001-d48f479b-fd6a-4623-b3d8-785fde48d824.png)


## Insight 📝

- Fix some broken code to ensure the generated project can run properly.
  - Missing `_dio` parameter in `AppInterceptor`.
  - No `injectable` integrated yet, we should remove it in `PermissionWrapper` and update it later.

## Proof Of Work 📹

The generated app can build and run locally ✅ 

<img src="https://user-images.githubusercontent.com/16315358/210606411-7896100e-f2a0-4816-9606-28ba257c7a4d.png" width=200 />

