### PR TITLE
[#139] Fix unit test command in README file

### DIFF
--- a/.template/README.md
+++ b/.template/README.md
@@ -42,7 +42,7 @@ Clone the repository
 
 - Run unit testing:
 
-  - `$ fvm flutter test .`
+  - `$ fvm flutter test`
 
 - Run integration testing:
 


### PR DESCRIPTION
- Solves #139

## What happened 👀

The unit test command in the README file is incorrect, therefore, we need to update it.

## Insight 📝

Update the unit test command in the README file from `$ fvm flutter test .` to `$ fvm flutter test`

## Proof Of Work 📹

![Screenshot 2566-02-02 at 11 30 07](https://user-images.githubusercontent.com/13492460/216231972-5bcbd859-881c-4866-a8ba-d91ccbbc94bf.png)
