### PR TITLE
[#138] Export MainActivity to support running on Android 12+

### DIFF
--- a/.template/android/app/src/main/AndroidManifest.xml
+++ b/.template/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"
+            android:exported="true"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"


### PR DESCRIPTION


- Solves #138 

## What happened 👀

Config Manifest file to support running on Android 12+

## Insight 📝

Export `MainActivity` tag inside Manifest

## Proof Of Work 📹

<img width="800" alt="Screen Shot 2023-02-08 at 11 43 28 PM" src="https://user-images.githubusercontent.com/88996251/217596186-e10d2add-e7e4-4785-a44e-83f27a398ea1.png">

